### PR TITLE
Updated for backend v3.1.2

### DIFF
--- a/functions/handlers/signTransaction.js
+++ b/functions/handlers/signTransaction.js
@@ -26,7 +26,7 @@ exports.signTransaction = (seedHex, transactionHex) => {
 
   const transactionBytes = new Buffer(transactionHex, "hex");
   const transactionHash = new Buffer(sha256.x2(transactionBytes), "hex");
-  const signature = privateKey.sign(transactionHash);
+  const signature = privateKey.sign(transactionHash, { canonical: true });
   const signatureBytes = new Buffer(signature.toDER());
   const signatureLength = uvarint64ToBuf(signatureBytes.length);
 


### PR DESCRIPTION
As per, https://github.com/deso-protocol/backend/issues/455

Added canonical: true to signing function.

`const signature = privateKey.sign(transactionHash, { canonical: true });`